### PR TITLE
Add properties to parameters to the screen event

### DIFF
--- a/Sources/SegmentFirebase/FirebaseDestination.swift
+++ b/Sources/SegmentFirebase/FirebaseDestination.swift
@@ -119,7 +119,8 @@ public class FirebaseDestination: DestinationPlugin {
             var parameters: [String: Any] = [FirebaseAnalytics.AnalyticsParameterScreenName: eventName]
             
             if let properties = event.properties?.dictionaryValue {
-                parameters = returnMappedFirebaseParameters(properties, for: FirebaseDestination.mappedKeys)
+                let propertiesParameters = returnMappedFirebaseParameters(properties, for: FirebaseDestination.mappedKeys)
+                parameters = parameters.merging(propertiesParameters) { (current, _) in current }
             }
 
             if let campaign = event.context?.dictionaryValue?["campaign"] as? [String: Any] {

--- a/Sources/SegmentFirebase/FirebaseDestination.swift
+++ b/Sources/SegmentFirebase/FirebaseDestination.swift
@@ -118,6 +118,10 @@ public class FirebaseDestination: DestinationPlugin {
         if let eventName = event.name {
             var parameters: [String: Any] = [FirebaseAnalytics.AnalyticsParameterScreenName: eventName]
             
+            if let properties = event.properties?.dictionaryValue {
+                parameters = returnMappedFirebaseParameters(properties, for: FirebaseDestination.mappedKeys)
+            }
+
             if let campaign = event.context?.dictionaryValue?["campaign"] as? [String: Any] {
                 let campaignParameters = returnMappedFirebaseParameters(campaign, for: FirebaseDestination.campaignMappedKeys)
                 parameters = parameters.merging(campaignParameters) { (current, _) in current }


### PR DESCRIPTION
The properties for `screen_view` events are not included into the parameters while we do expect them to be there. 
This PR adds them in the same way as it is done for "track" events.