### PR TITLE
Mapped Product Clicked to select_item

### DIFF
--- a/Sources/SegmentFirebase/FirebaseDestination.swift
+++ b/Sources/SegmentFirebase/FirebaseDestination.swift
@@ -219,7 +219,7 @@ private struct FirebaseSettings: Codable {
 
 private extension FirebaseDestination {
     
-    static let mappedValues = ["Product Clicked": FirebaseAnalytics.AnalyticsEventSelectContent,
+    static let mappedValues = ["Product Clicked": FirebaseAnalytics.AnalyticsEventSelectItem,
                                "Product Viewed": FirebaseAnalytics.AnalyticsEventViewItem,
                                "Product Added": FirebaseAnalytics.AnalyticsEventAddToCart,
                                "Product Removed": FirebaseAnalytics.AnalyticsEventRemoveFromCart,


### PR DESCRIPTION
`select_item` contains the `items` event property ([docs](https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event#SELECT_ITEM())). `select_content` does not contain `items` ([docs](https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event#SELECT_CONTENT()))

This is significant because the other GA4/Firebase ecommerce events such as:
- view_item_list ([docs](https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event#VIEW_ITEM_LIST()))
- view_item ([docs](https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event#VIEW_ITEM_LIST()))
- purchase ([docs](https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event#PURCHASE()))
- etc

All contain the `items` property. 

A fairly standard ecommerce flow is:
1. View Product List (`view_item_list`)
2. Select Product from List (could be `select_item`, but is currently `select_content`)
3. View Product Detail Page (`view_item`)
4. Add to Cart (`add_to_cart`)
5. Checkout Steps (`begin_checkout`)
6. Purchase (`purchase`)

All of the above steps are replicated with Firebase/GA4 events. All of those events, except for `select_content` have `items`, which map to the products array for the Segment implementation. `select_content` breaks a pattern and is preventing our products from appearing in Firebase/GA4 when our Segment Product Clicked event is fired.

We are proposing that Product Clicked gets mapped to `select_item` instead of `select_content`.

Docs:
- [Current Segment -> Firebase/GA4 Event Name Mapping](https://segment.com/docs/connections/destinations/catalog/firebase/#event-mappings)

cc: @jordantannenbaum1