### PR TITLE
Update GitHub Actions to fix deprecation warnings

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -22,8 +22,8 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
+    - uses: actions/checkout@v4
+    - uses: actions/cache@v4
       with:
         path: /Users/runner/Library/Developer/Xcode/DerivedData
         key: ${{ runner.os }}-spm-examples-${{ hashFiles('**/Package.resolved') }}


### PR DESCRIPTION
- Update actions/checkout from v2 to v4
- Update actions/cache from v2 to v4