### PR TITLE
Add Firebase 12.x support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/google/abseil-cpp-binary.git",
         "state": {
           "branch": null,
-          "revision": "194a6706acbd25e4ef639bcaddea16e8758a3e27",
-          "version": "1.2024011602.0"
+          "revision": "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+          "version": "1.2024072200.0"
         }
       },
       {
@@ -33,8 +33,17 @@
         "repositoryURL": "https://github.com/firebase/firebase-ios-sdk",
         "state": {
           "branch": null,
-          "revision": "9118aca998dbe2ceac45d64b21a91c6376928df7",
-          "version": "11.1.0"
+          "revision": "52548902007e7beda99fcdca31f62eccc4befe38",
+          "version": "12.11.0"
+        }
+      },
+      {
+        "package": "GoogleAdsOnDeviceConversion",
+        "repositoryURL": "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+        "state": {
+          "branch": null,
+          "revision": "7b722132d1f2ab421c88a2e5c384c984cebd0d00",
+          "version": "3.4.0"
         }
       },
       {
@@ -42,8 +51,8 @@
         "repositoryURL": "https://github.com/google/GoogleAppMeasurement.git",
         "state": {
           "branch": null,
-          "revision": "07a2f57d147d2bf368a0d2dcb5579ff082d9e44f",
-          "version": "11.1.0"
+          "revision": "1657f705bc70255ff9d66dfcc697a85db164998f",
+          "version": "12.11.0"
         }
       },
       {
@@ -60,8 +69,8 @@
         "repositoryURL": "https://github.com/google/GoogleUtilities.git",
         "state": {
           "branch": null,
-          "revision": "53156c7ec267db846e6b64c9f4c4e31ba4cf75eb",
-          "version": "8.0.2"
+          "revision": "60da361632d0de02786f709bdc0c4df340f7613e",
+          "version": "8.1.0"
         }
       },
       {
@@ -69,8 +78,8 @@
         "repositoryURL": "https://github.com/google/grpc-binary.git",
         "state": {
           "branch": null,
-          "revision": "f56d8fc3162de9a498377c7b6cea43431f4f5083",
-          "version": "1.65.1"
+          "revision": "75b31c842f664a0f46a2e590a570e370249fd8f6",
+          "version": "1.69.1"
         }
       },
       {
@@ -87,8 +96,8 @@
         "repositoryURL": "https://github.com/google/interop-ios-for-google-sdks.git",
         "state": {
           "branch": null,
-          "revision": "2d12673670417654f08f5f90fdd62926dc3a2648",
-          "version": "100.0.0"
+          "revision": "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+          "version": "101.0.0"
         }
       },
       {
@@ -125,15 +134,6 @@
           "branch": null,
           "revision": "64f3b5150c282a34af4578188dce2fd597e600e3",
           "version": "1.1.0"
-        }
-      },
-      {
-        "package": "SwiftProtobuf",
-        "repositoryURL": "https://github.com/apple/swift-protobuf.git",
-        "state": {
-          "branch": null,
-          "revision": "e1499bc69b9040b29184f7f2996f7bab467c1639",
-          "version": "1.19.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
 		.package(
 			name: "Firebase",
 			url: "https://github.com/firebase/firebase-ios-sdk",
-			from: "11.1.0"
+			from: "12.0.0"
 		)
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -7,8 +7,8 @@ let package = Package(
     name: "SegmentFirebase",
     platforms: [
         .macOS("10.15"),
-        .iOS("13.0"),
-        .tvOS("13.0"),
+        .iOS("15.0"),
+        .tvOS("15.0"),
         .watchOS("7.1")
     ],
     products: [

--- a/README.md
+++ b/README.md
@@ -1,14 +1,10 @@
-# Analytics-Swift Firebase (Fork)
-
-> **This is a fork of [segment-integrations/analytics-swift-firebase](https://github.com/segment-integrations/analytics-swift-firebase)** updated to support **Firebase Apple SDK 12.x**.
+# Analytics-Swift Firebase
 
 Add Firebase device mode support to your applications via this plugin for [Analytics-Swift](https://github.com/segmentio/analytics-swift)
 
-## Changes from upstream
+⚠️ **Github Issues disabled in this repository** ⚠️
 
-- Updated Firebase dependency from `~> 11.x` to `>= 12.0.0`
-- Replaced `import Firebase` with `import FirebaseCore` (recommended for Firebase 12+)
-- Bumped `swift-tools-version` to 5.9
+Please direct all issues, bug reports, and feature enhancements to `friends@segment.com` so they can be resolved as efficiently as possible.
 
 ## Adding the dependency
 
@@ -17,20 +13,22 @@ Add Firebase device mode support to your applications via this plugin for [Analy
 ### via Xcode
 In the Xcode `File` menu, click `Add Packages`.  You'll see a dialog where you can search for Swift packages.  In the search field, enter the URL to this repo.
 
-https://github.com/sSahad/analytics-swift-firebase
+https://github.com/segment-integrations/analytics-swift-firebase
 
 You'll then have the option to pin to a version, or specific branch, as well as which project in your workspace to add it to.  Once you've made your selections, click the `Add Package` button.
 
 ### via Package.swift
 
-Open your Package.swift file and add the following to your the `dependencies` section:
+Open your Package.swift file and add the following do your the `dependencies` section:
 
-```swift
-.package(
-    url: "https://github.com/sSahad/analytics-swift-firebase.git",
-    branch: "main"
-),
 ```
+.package(
+            name: "Segment",
+            url: "https://github.com/segment-integrations/analytics-swift-firebase.git",
+            from: "1.1.3"
+        ),
+```
+
 
 *Note the Firebase library itself will be installed as an additional dependency.*
 
@@ -39,14 +37,14 @@ Open your Package.swift file and add the following to your the `dependencies` se
 
 Open the file where you setup and configure the Analytics-Swift library.  Add this plugin to the list of imports.
 
-```swift
+```
 import Segment
 import SegmentFirebase // <-- Add this line
 ```
 
 Just under your Analytics-Swift library setup, call `analytics.add(plugin: ...)` to add an instance of the plugin to the Analytics timeline.
 
-```swift
+```
 let analytics = Analytics(configuration: Configuration(writeKey: "<YOUR WRITE KEY>")
                     .flushAt(3)
                     .trackApplicationLifecycleEvents(true))
@@ -55,6 +53,14 @@ analytics.add(plugin: FirebaseDestination())
 
 Your events will now begin to flow to Firebase in device mode.
 
+
+## Support
+
+Please use Github issues, Pull Requests, or feel free to reach out to our [support team](https://segment.com/help/).
+
+## Integrating with Segment
+
+Interested in integrating your service with us? Check out our [Partners page](https://segment.com/partners/) for more details.
 
 ## License
 ```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
-# Analytics-Swift Firebase
+# Analytics-Swift Firebase (Fork)
+
+> **This is a fork of [segment-integrations/analytics-swift-firebase](https://github.com/segment-integrations/analytics-swift-firebase)** updated to support **Firebase Apple SDK 12.x**.
 
 Add Firebase device mode support to your applications via this plugin for [Analytics-Swift](https://github.com/segmentio/analytics-swift)
 
-⚠️ **Github Issues disabled in this repository** ⚠️
+## Changes from upstream
 
-Please direct all issues, bug reports, and feature enhancements to `friends@segment.com` so they can be resolved as efficiently as possible. 
+- Updated Firebase dependency from `~> 11.x` to `>= 12.0.0`
+- Replaced `import Firebase` with `import FirebaseCore` (recommended for Firebase 12+)
+- Bumped `swift-tools-version` to 5.9
 
 ## Adding the dependency
 
@@ -13,22 +17,20 @@ Please direct all issues, bug reports, and feature enhancements to `friends@segm
 ### via Xcode
 In the Xcode `File` menu, click `Add Packages`.  You'll see a dialog where you can search for Swift packages.  In the search field, enter the URL to this repo.
 
-https://github.com/segment-integrations/analytics-swift-firebase
+https://github.com/sSahad/analytics-swift-firebase
 
-You'll then have the option to pin to a version, or specific branch, as well as which project in your workspace to add it to.  Once you've made your selections, click the `Add Package` button.  
+You'll then have the option to pin to a version, or specific branch, as well as which project in your workspace to add it to.  Once you've made your selections, click the `Add Package` button.
 
 ### via Package.swift
 
-Open your Package.swift file and add the following do your the `dependencies` section:
+Open your Package.swift file and add the following to your the `dependencies` section:
 
-```
+```swift
 .package(
-            name: "Segment",
-            url: "https://github.com/segment-integrations/analytics-swift-firebase.git",
-            from: "1.1.3"
-        ),
+    url: "https://github.com/sSahad/analytics-swift-firebase.git",
+    branch: "main"
+),
 ```
-
 
 *Note the Firebase library itself will be installed as an additional dependency.*
 
@@ -37,14 +39,14 @@ Open your Package.swift file and add the following do your the `dependencies` se
 
 Open the file where you setup and configure the Analytics-Swift library.  Add this plugin to the list of imports.
 
-```
+```swift
 import Segment
 import SegmentFirebase // <-- Add this line
 ```
 
 Just under your Analytics-Swift library setup, call `analytics.add(plugin: ...)` to add an instance of the plugin to the Analytics timeline.
 
-```
+```swift
 let analytics = Analytics(configuration: Configuration(writeKey: "<YOUR WRITE KEY>")
                     .flushAt(3)
                     .trackApplicationLifecycleEvents(true))
@@ -53,14 +55,6 @@ analytics.add(plugin: FirebaseDestination())
 
 Your events will now begin to flow to Firebase in device mode.
 
-
-## Support
-
-Please use Github issues, Pull Requests, or feel free to reach out to our [support team](https://segment.com/help/).
-
-## Integrating with Segment
-
-Interested in integrating your service with us? Check out our [Partners page](https://segment.com/partners/) for more details.
 
 ## License
 ```

--- a/Sources/SegmentFirebase/FirebaseDestination.swift
+++ b/Sources/SegmentFirebase/FirebaseDestination.swift
@@ -29,7 +29,7 @@
 
 import Foundation
 import Segment
-import Firebase
+import FirebaseCore
 import FirebaseAnalytics
 
 /**
@@ -56,12 +56,6 @@ open class FirebaseDestination: DestinationPlugin {
     open func update(settings: Settings, type: UpdateType) {
         // we've already set up this singleton SDK, can't do it again, so skip.
         guard type == .initial else { return }
-        
-        guard let firebaseSettings: FirebaseSettings = settings.integrationSettings(forPlugin: self) else { return }
-        if let deepLinkURLScheme = firebaseSettings.deepLinkURLScheme {
-            FirebaseOptions.defaultOptions()?.deepLinkURLScheme = deepLinkURLScheme
-            analytics?.log(message: "Added deepLinkURLScheme: \(deepLinkURLScheme)")
-        }
         
         // First check if firebase has been set up from a previous settings call
         if (FirebaseApp.app() != nil) {
@@ -218,10 +212,6 @@ extension FirebaseDestination {
     }
 }
 
-
-private struct FirebaseSettings: Codable {
-    let deepLinkURLScheme: String?
-}
 
 private extension FirebaseDestination {
     


### PR DESCRIPTION
 ## Summary

  Updates the Firebase dependency to support Firebase Apple SDK 12.x (`from: "12.0.0"`).

  Firebase 12 introduced several breaking changes that affect this plugin:

  ### Changes

  - **Bumped Firebase dependency** from `from: "11.1.0"` to `from: "12.0.0"`
  - **Replaced `import Firebase` with `import FirebaseCore`** — the umbrella `Firebase` module import
  is deprecated in Firebase 12; `FirebaseApp` and `FirebaseOptions` are in `FirebaseCore`
  - **Removed `deepLinkURLScheme` configuration** — `FirebaseOptions.deepLinkURLScheme` was removed in
  Firebase 12 as part of the [Firebase Dynamic Links
  sunset](https://firebase.google.com/support/dynamic-links-faq). This property no longer compiles
  against Firebase 12.x. The associated `FirebaseSettings` struct (which only held `deepLinkURLScheme`)
   was also removed as it became unused.
  - **Bumped `swift-tools-version`** from 5.3 to 5.9
  - **Bumped minimum iOS platform** from 13.0 to 15.0 (required by Firebase 12)

  ### Why

  Without this change, any project using `analytics-swift-firebase` cannot upgrade to Firebase 12.x —
  SPM's `from: "11.1.0"` constraint resolves to `>= 11.1.0, < 12.0.0`, causing a version conflict.

  ### Testing

  - Verified the package builds successfully with `swift build` against Firebase 12.11.0
  - Integrated in a production iOS app and confirmed Firebase Analytics events flow correctly via
  `FirebaseDestination`