### PR TITLE
Update Firebase dependency and remove FirebaseSettings

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/google/abseil-cpp-binary.git",
         "state": {
           "branch": null,
-          "revision": "194a6706acbd25e4ef639bcaddea16e8758a3e27",
-          "version": "1.2024011602.0"
+          "revision": "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+          "version": "1.2024072200.0"
         }
       },
       {
@@ -33,8 +33,17 @@
         "repositoryURL": "https://github.com/firebase/firebase-ios-sdk",
         "state": {
           "branch": null,
-          "revision": "9118aca998dbe2ceac45d64b21a91c6376928df7",
-          "version": "11.1.0"
+          "revision": "d47760f97a853808be6a045d278fbd12abf546b6",
+          "version": "12.12.0"
+        }
+      },
+      {
+        "package": "GoogleAdsOnDeviceConversion",
+        "repositoryURL": "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+        "state": {
+          "branch": null,
+          "revision": "23fa6970874ec8f3ac0039b3778ca8d6545d50ee",
+          "version": "3.4.2"
         }
       },
       {
@@ -42,8 +51,8 @@
         "repositoryURL": "https://github.com/google/GoogleAppMeasurement.git",
         "state": {
           "branch": null,
-          "revision": "07a2f57d147d2bf368a0d2dcb5579ff082d9e44f",
-          "version": "11.1.0"
+          "revision": "1657f705bc70255ff9d66dfcc697a85db164998f",
+          "version": "12.11.0"
         }
       },
       {
@@ -60,8 +69,8 @@
         "repositoryURL": "https://github.com/google/GoogleUtilities.git",
         "state": {
           "branch": null,
-          "revision": "53156c7ec267db846e6b64c9f4c4e31ba4cf75eb",
-          "version": "8.0.2"
+          "revision": "60da361632d0de02786f709bdc0c4df340f7613e",
+          "version": "8.1.0"
         }
       },
       {
@@ -69,8 +78,8 @@
         "repositoryURL": "https://github.com/google/grpc-binary.git",
         "state": {
           "branch": null,
-          "revision": "f56d8fc3162de9a498377c7b6cea43431f4f5083",
-          "version": "1.65.1"
+          "revision": "75b31c842f664a0f46a2e590a570e370249fd8f6",
+          "version": "1.69.1"
         }
       },
       {
@@ -87,8 +96,8 @@
         "repositoryURL": "https://github.com/google/interop-ios-for-google-sdks.git",
         "state": {
           "branch": null,
-          "revision": "2d12673670417654f08f5f90fdd62926dc3a2648",
-          "version": "100.0.0"
+          "revision": "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+          "version": "101.0.0"
         }
       },
       {
@@ -125,15 +134,6 @@
           "branch": null,
           "revision": "64f3b5150c282a34af4578188dce2fd597e600e3",
           "version": "1.1.0"
-        }
-      },
-      {
-        "package": "SwiftProtobuf",
-        "repositoryURL": "https://github.com/apple/swift-protobuf.git",
-        "state": {
-          "branch": null,
-          "revision": "e1499bc69b9040b29184f7f2996f7bab467c1639",
-          "version": "1.19.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -7,8 +7,8 @@ let package = Package(
     name: "SegmentFirebase",
     platforms: [
         .macOS("10.15"),
-        .iOS("13.0"),
-        .tvOS("13.0"),
+        .iOS("15.0"),
+        .tvOS("15.0"),
         .watchOS("7.1")
     ],
     products: [
@@ -28,7 +28,7 @@ let package = Package(
 		.package(
 			name: "Firebase",
 			url: "https://github.com/firebase/firebase-ios-sdk",
-			from: "11.1.0"
+			from: "12.0.0"
 		)
     ],
     targets: [

--- a/Sources/SegmentFirebase/FirebaseDestination.swift
+++ b/Sources/SegmentFirebase/FirebaseDestination.swift
@@ -57,12 +57,8 @@ open class FirebaseDestination: DestinationPlugin {
         // we've already set up this singleton SDK, can't do it again, so skip.
         guard type == .initial else { return }
         
-        guard let firebaseSettings: FirebaseSettings = settings.integrationSettings(forPlugin: self) else { return }
-        if let deepLinkURLScheme = firebaseSettings.deepLinkURLScheme {
-            FirebaseOptions.defaultOptions()?.deepLinkURLScheme = deepLinkURLScheme
-            analytics?.log(message: "Added deepLinkURLScheme: \(deepLinkURLScheme)")
-        }
-        
+        guard settings.hasIntegrationSettings(forPlugin: self) else { return }
+
         // First check if firebase has been set up from a previous settings call
         if (FirebaseApp.app() != nil) {
             analytics?.log(message: "Firebase already configured, skipping")
@@ -217,12 +213,6 @@ extension FirebaseDestination {
         }
     }
 }
-
-
-private struct FirebaseSettings: Codable {
-    let deepLinkURLScheme: String?
-}
-
 private extension FirebaseDestination {
     
     static let mappedValues = ["Product Clicked": FirebaseAnalytics.AnalyticsEventSelectItem,


### PR DESCRIPTION
## Summary
- update `firebase-ios-sdk` from `11.1.0` to `12.x` and raise the package's iOS/tvOS minimums to `15.0`
- remove the now-unused `FirebaseSettings` type and gate initialization with `hasIntegrationSettings(forPlugin:)`
- refresh `Package.resolved` for the Firebase 12 transitive dependency graph

## Why
Firebase 12 requires newer platform baselines, and the local `FirebaseSettings` model is no longer needed after removing the deep link URL scheme wiring.

## Impact
Consumers of `SegmentFirebase` will resolve Firebase 12-compatible dependencies and no longer carry the unused integration settings model.
